### PR TITLE
Update for mongoose 4.7.x

### DIFF
--- a/lib/mongoose-validate-all.js
+++ b/lib/mongoose-validate-all.js
@@ -6,7 +6,7 @@
  */
 function ValidationGroup(validatorsArray) {
   var validationErrors;
-  
+
   /*
    * Iterates through the supplied validators,
    * appending error messages to validationErrors
@@ -15,21 +15,22 @@ function ValidationGroup(validatorsArray) {
    * @param value
    */
   function validator(value) {
+    var document = this;
     validationErrors = [];
     var isValid = true;
-    
+
     validatorsArray.forEach(function(validator) {
-      if(!validator.validator(value)) {
+      if(!validator.validator.call(document, value)) {
         // Append message
-        validationErrors.push(validator.msg);
+        validationErrors.push(validator.message);
 
         isValid = false;
       }
     });
     return isValid;
   }
-  
-  /* 
+
+  /*
    * Simple object to retrieve the list of
    * validation errors.
    *
@@ -51,18 +52,20 @@ function ValidationGroup(validatorsArray) {
     for(var i = 0; i < validationErrors.length; i++) {
       validationErrors[i] = validationErrors[i].replace(regexp, newSubStr);
     }
-    
-    return JSON.stringify(validationErrors);
+
+    return validationErrors.toString();
   };
-  
-  /* 
+
+  /*
    * For a single validation method, Mongoose expects
    * an array containing the validation method and
    * error message respectively.
    */
   return [
-    validator,
-    new ValidationErrorRetriever()
+    {
+      validator,
+      message: new ValidationErrorRetriever()
+    }
   ];
 }
 


### PR DESCRIPTION
- Updated to work with mongoose 4.7.x
- Bind mongoose document to validator
- Return list (Array.toString()) instead of JSON (faster and easier handling with .split(',') always returning an array)

Todo
- [ ] adjust readme
- [ ] add testcase?
- [ ] major version bumb?